### PR TITLE
Strip miliseconds from data_hora to fix safari 'invalid date' error

### DIFF
--- a/src/components/VaccinePointBox/VaccinePointBox.tsx
+++ b/src/components/VaccinePointBox/VaccinePointBox.tsx
@@ -61,7 +61,7 @@ const VaccinePointBox = ({
     <p>
       Data e hora da última atualização:{' '}
       <span className={styles.content}>
-        {new Date(data_hora).toLocaleString('pt-BR')}
+        {new Date(data_hora.replace(/\.\n+$/, '')).toLocaleString('pt-BR')}
       </span>
     </p>
     <a


### PR DESCRIPTION
Idk if this is the desired fix, I couldn't test locally because I don't have the environment vars :P